### PR TITLE
fix: Use existing shadowRoot if available in BaseElementController constructor

### DIFF
--- a/src/base-element.ts
+++ b/src/base-element.ts
@@ -67,7 +67,7 @@ export abstract class BaseElementController {
 
   constructor(e: HTMLElement) {
     this.e = e;
-    this.root = this.e.attachShadow({ mode: 'open' });
+    this.root = this.e.shadowRoot || this.e.attachShadow({ mode: 'open' });
   }
 
   protected $<T extends HTMLElement>(id: string): T {


### PR DESCRIPTION
## Summary
Fixes an issue where `BaseElementController` would attempt to attach a shadow root even if one already exists, which would throw an error.

## Changes
- Modified the `BaseElementController` constructor to check for an existing `shadowRoot` before attempting to attach a new one
- Changed from `this.e.attachShadow({ mode: 'open' })` to `this.e.shadowRoot || this.e.attachShadow({ mode: 'open' })`

## Why
When a custom element already has a shadow root attached, calling `attachShadow()` again throws a `NotSupportedError`. This change ensures compatibility with elements that may have had their shadow root attached elsewhere or are being re-initialized.

## Impact
- Prevents runtime errors when `BaseElementController` is instantiated with an element that already has a shadow root
- Maintains backward compatibility for elements without an existing shadow root